### PR TITLE
Lock body scroll when feature modals are open

### DIFF
--- a/src/components/cta/CustomerJourneyCTAs.tsx
+++ b/src/components/cta/CustomerJourneyCTAs.tsx
@@ -22,6 +22,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { useToast } from '@/hooks/use-toast';
 import { cn } from '@/lib/utils';
 import { useReducedMotionSafe } from '@/hooks/useReducedMotionSafe';
+import { useBodyScrollLock } from '@/hooks/use-body-scroll-lock';
 
 interface CTAAction {
   id: string;
@@ -53,6 +54,8 @@ const ReserveModal: React.FC<{ isOpen: boolean; onClose: () => void; onSubmit: (
     onSubmit(formData);
     onClose();
   };
+
+  useBodyScrollLock(isOpen);
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
@@ -140,6 +143,8 @@ const TestDriveModal: React.FC<{ isOpen: boolean; onClose: () => void; onSubmit:
     onSubmit(formData);
     onClose();
   };
+
+  useBodyScrollLock(isOpen);
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
@@ -269,6 +274,8 @@ const ServiceModal: React.FC<{ isOpen: boolean; onClose: () => void; onSubmit: (
     onClose();
   };
 
+  useBodyScrollLock(isOpen);
+
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
       <DialogContent className="max-w-md">
@@ -393,6 +400,8 @@ const TradeInModal: React.FC<{ isOpen: boolean; onClose: () => void; onSubmit: (
     onSubmit(formData);
     onClose();
   };
+
+  useBodyScrollLock(isOpen);
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>

--- a/src/components/home/OffersModal.tsx
+++ b/src/components/home/OffersModal.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { X, Phone, Mail, MapPin, Calendar, Gift, Star } from "lucide-react";
+import { useBodyScrollLock } from "@/hooks/use-body-scroll-lock";
 
 interface OffersModalProps {
   isOpen: boolean;
@@ -15,11 +16,13 @@ interface OffersModalProps {
   selectedOffer?: any;
 }
 
-const OffersModal: React.FC<OffersModalProps> = ({ 
-  isOpen, 
-  onClose, 
-  selectedOffer 
+const OffersModal: React.FC<OffersModalProps> = ({
+  isOpen,
+  onClose,
+  selectedOffer
 }) => {
+  useBodyScrollLock(isOpen);
+
   const defaultOffer = {
     id: 1,
     title: "0% Interest Rate",

--- a/src/components/home/QuickViewModal.tsx
+++ b/src/components/home/QuickViewModal.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { VehicleModel } from '@/types/vehicle';
 import { Persona } from '@/types/persona';
+import { useBodyScrollLock } from '@/hooks/use-body-scroll-lock';
 
 interface QuickViewModalProps {
   vehicle: VehicleModel;
@@ -13,6 +14,8 @@ interface QuickViewModalProps {
 }
 
 const QuickViewModal: React.FC<QuickViewModalProps> = ({ vehicle, onClose, personaData }) => {
+  useBodyScrollLock(true);
+
   // Prevent clicks inside the modal from closing it
   const handleModalClick = (e: React.MouseEvent) => {
     e.stopPropagation();

--- a/src/components/vehicle-details/GradeComparisonModal.tsx
+++ b/src/components/vehicle-details/GradeComparisonModal.tsx
@@ -9,10 +9,10 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
-import { 
-  X, 
-  Check, 
-  Download, 
+import {
+  X,
+  Check,
+  Download,
   Wrench, 
   Sparkles,
   Eye,
@@ -25,6 +25,7 @@ import {
 } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { openTestDrivePopup } from "@/utils/testDriveUtils";
+import { useBodyScrollLock } from "@/hooks/use-body-scroll-lock";
 
 interface GradeComparisonModalProps {
   isOpen: boolean;
@@ -51,6 +52,8 @@ const GradeComparisonModal: React.FC<GradeComparisonModalProps> = ({
   onCarBuilder,
   onBookTestDrive
 }) => {
+  useBodyScrollLock(isOpen);
+
   const [selectedGrades, setSelectedGrades] = useState<number[]>([0, 1]);
   const [showOnlyDifferences, setShowOnlyDifferences] = useState(false);
   const [expandedSections, setExpandedSections] = useState<string[]>(['pricing', 'engine', 'specs']);

--- a/src/components/vehicle-details/PremiumMediaShowcase.tsx
+++ b/src/components/vehicle-details/PremiumMediaShowcase.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useCallback } from "react";
+import React, { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { VehicleModel } from "@/types/vehicle";
@@ -15,6 +15,7 @@ import {
   X,
   Car,
 } from "lucide-react";
+import { useBodyScrollLock } from "@/hooks/use-body-scroll-lock";
 
 /* ─────────────────────────────────────────────────────────
    Types
@@ -101,17 +102,6 @@ function Hotspot({
   );
 }
 
-function useLockBodyScroll() {
-  useEffect(() => {
-    const b = document.body;
-    const prev = b.style.overflow;
-    b.style.overflow = "hidden";
-    return () => {
-      b.style.overflow = prev;
-    };
-  }, []);
-}
-
 /* ─────────────────────────────────────────────────────────
    Modals
 ────────────────────────────────────────────────────────── */
@@ -128,7 +118,7 @@ function PerformanceModal({
 }) {
   const [i, setI] = useState(0);
   const s = item.gallery[i];
-  useLockBodyScroll();
+  useBodyScrollLock(true);
 
   return (
     <div className="fixed inset-0 z-50 bg-black/85">
@@ -200,7 +190,7 @@ function SafetyModal({
   onClose: () => void;
   onBook?: () => void;
 }) {
-  useLockBodyScroll();
+  useBodyScrollLock(true);
   const v = item.video;
   const src = v
     ? v.provider === "youtube"
@@ -248,7 +238,7 @@ function SafetyModal({
 
 // 3. Interior
 function InteriorModal({ item, onClose }: { item: MediaItem; onClose: () => void }) {
-  useLockBodyScroll();
+  useBodyScrollLock(true);
   const [i, setI] = useState(0);
   const s = item.gallery[i];
 
@@ -293,7 +283,7 @@ function QualityModal({
   onClose: () => void;
   onBook?: () => void;
 }) {
-  useLockBodyScroll();
+  useBodyScrollLock(true);
   const img = item.gallery[0]?.url || FALLBACK;
   return (
     <div className="fixed inset-0 z-50 bg-white">
@@ -334,7 +324,7 @@ function TechnologyModal({
   onClose: () => void;
   onBook?: () => void;
 }) {
-  useLockBodyScroll();
+  useBodyScrollLock(true);
   const img = item.gallery[0]?.url || FALLBACK;
   return (
     <div className="fixed inset-0 z-50 grid md:grid-cols-[1fr_340px] bg-[#071a1e] text-cyan-50">
@@ -370,7 +360,7 @@ function TechnologyModal({
 
 // 6. Handling
 function HandlingModal({ item, onClose }: { item: MediaItem; onClose: () => void }) {
-  useLockBodyScroll();
+  useBodyScrollLock(true);
   const [mode, setMode] = useState(item.gallery[0]?.title || "Normal");
   const s = item.gallery.find((g) => g.title === mode) ?? item.gallery[0];
 

--- a/src/components/vehicle-details/VehicleMediaShowcase.tsx
+++ b/src/components/vehicle-details/VehicleMediaShowcase.tsx
@@ -1,6 +1,7 @@
 // src/components/vehicle-details/VehicleMediaShowcase.tsx
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import ReactDOM from "react-dom";
+import { useBodyScrollLock } from "@/hooks/use-body-scroll-lock";
 import type { VehicleModel } from "@/types/vehicle";
 
 /* ================= Brand tokens ================= */
@@ -15,15 +16,6 @@ const TOK = {
 
 const cx = (...a: Array<string | false | null | undefined>) => a.filter(Boolean).join(" ");
 
-/* ================= Utilities ================= */
-function useBodyScrollLock(locked: boolean) {
-  useEffect(() => {
-    if (!locked) return;
-    const prev = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => { document.body.style.overflow = prev; };
-  }, [locked]);
-}
 function usePrefersReducedMotion() {
   const [reduced, setReduced] = useState(false);
   useEffect(() => {

--- a/src/components/vehicle-details/modals/ConnectivityModal.tsx
+++ b/src/components/vehicle-details/modals/ConnectivityModal.tsx
@@ -15,6 +15,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
+import { useBodyScrollLock } from "@/hooks/use-body-scroll-lock";
 
 /* -------------------------------------------------------------------------- */
 /*                                   Types                                    */
@@ -223,6 +224,8 @@ const ConnectivityModal: React.FC<ConnectivityModalProps> = ({
   modelName = "Toyota Camry",
   regionLabel = "UAE",
 }) => {
+  useBodyScrollLock(isOpen);
+
   const [mediaTab, setMediaTab] = React.useState<MediaTab>("image");
   const prefersReducedMotion = useReducedMotion();
 

--- a/src/components/vehicle-details/modals/HybridTechModal.tsx
+++ b/src/components/vehicle-details/modals/HybridTechModal.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/mobile-optimized-dialog";
 import CollapsibleContent from "@/components/ui/collapsible-content";
 import { cn } from "@/lib/utils";
+import { useBodyScrollLock } from "@/hooks/use-body-scroll-lock";
 
 /* ----------------------------------------------------------------------------
    Brand & Assets
@@ -349,6 +350,8 @@ const HybridTechModal: React.FC<HybridTechModalProps> = ({
   onBookTestDrive,
   videoIds = [],
 }) => {
+  useBodyScrollLock(isOpen);
+
   const prefersReduced = useReducedMotion();
   const enter = prefersReduced ? {} : { opacity: 0, y: 16 };
   const entered = prefersReduced ? {} : { opacity: 1, y: 0 };

--- a/src/components/vehicle-details/modals/InteriorExperienceModal.tsx
+++ b/src/components/vehicle-details/modals/InteriorExperienceModal.tsx
@@ -13,6 +13,7 @@ import {
   MobileOptimizedDialogDescription,
 } from "@/components/ui/mobile-optimized-dialog";
 import { cn } from "@/lib/utils";
+import { useBodyScrollLock } from "@/hooks/use-body-scroll-lock";
 
 const TOYOTA_RED = "#cb0017";
 
@@ -209,6 +210,8 @@ const InteriorExperienceModal: React.FC<InteriorExperienceModalProps> = ({
   videos = [],
   gallery,
 }) => {
+  useBodyScrollLock(isOpen);
+
   const prefersReduced = useReducedMotion();
   const enter = prefersReduced ? {} : { opacity: 0, y: 16 };
   const entered = prefersReduced ? {} : { opacity: 1, y: 0 };

--- a/src/components/vehicle-details/modals/SafetySuiteModal.tsx
+++ b/src/components/vehicle-details/modals/SafetySuiteModal.tsx
@@ -17,6 +17,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import CollapsibleContent from "@/components/ui/collapsible-content";
 import { cn } from "@/lib/utils";
+import { useBodyScrollLock } from "@/hooks/use-body-scroll-lock";
 
 /* -------------------------------------------------------------------------- */
 /*                                  Config                                     */
@@ -250,6 +251,8 @@ const SafetySuiteModal: React.FC<SafetySuiteModalProps> = ({
   modelName = "Toyota Camry",
   regionLabel = "UAE",
 }) => {
+  useBodyScrollLock(isOpen);
+
   const prefersReduced = useReducedMotion();
   const [scenario, setScenario] = React.useState<ScenarioKey>("laneDrift");
 

--- a/src/hooks/use-body-scroll-lock.ts
+++ b/src/hooks/use-body-scroll-lock.ts
@@ -1,0 +1,50 @@
+import { useEffect, useRef } from "react";
+
+let bodyScrollLockCount = 0;
+let previousOverflow: string | null = null;
+
+/**
+ * Locks body scrolling while `active` is true.
+ * Uses a reference count so multiple modals can be open simultaneously
+ * without unlocking the body prematurely.
+ */
+export function useBodyScrollLock(active: boolean) {
+  const isLocked = useRef(false);
+
+  useEffect(() => {
+    if (!active || typeof document === "undefined") {
+      return;
+    }
+
+    const { body } = document;
+    if (!body) {
+      return;
+    }
+
+    if (!isLocked.current) {
+      if (bodyScrollLockCount === 0) {
+        previousOverflow = body.style.overflow;
+        body.style.overflow = "hidden";
+      }
+
+      bodyScrollLockCount += 1;
+      isLocked.current = true;
+    }
+
+    return () => {
+      if (!isLocked.current || typeof document === "undefined") {
+        return;
+      }
+
+      const { body } = document;
+      bodyScrollLockCount = Math.max(0, bodyScrollLockCount - 1);
+
+      if (bodyScrollLockCount === 0 && body) {
+        body.style.overflow = previousOverflow ?? "";
+        previousOverflow = null;
+      }
+
+      isLocked.current = false;
+    };
+  }, [active]);
+}


### PR DESCRIPTION
## Summary
- add a shared `useBodyScrollLock` hook that reference-counts document overflow changes
- apply the scroll locking hook across vehicle feature modals, quick view/offers dialogs, and CTA modals so the page cannot scroll while they are open
- ensure each modal cleans up the lock when it closes to avoid interfering with other overlays

## Testing
- npm run lint *(fails: existing repository lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d6782dda388327811924cf3c2a93df