### PR TITLE
Add safe mobile nav padding

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -554,11 +554,25 @@
 
 .mobile-main-with-nav {
   min-height: calc(100dvh - var(--mobile-nav-height, 64px));
+  padding-bottom: calc(
+    var(--mobile-nav-height, 64px) +
+    max(
+      var(--mobile-nav-bottom, env(safe-area-inset-bottom, 0px)),
+      env(safe-area-inset-bottom, 0px)
+    )
+  );
 }
 
 @supports not (height: 100dvh) {
   .mobile-main-with-nav {
     min-height: calc(100vh - var(--mobile-nav-height, 64px));
+    padding-bottom: calc(
+      var(--mobile-nav-height, 64px) +
+      max(
+        var(--mobile-nav-bottom, env(safe-area-inset-bottom, 0px)),
+        env(safe-area-inset-bottom, 0px)
+      )
+    );
   }
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -556,10 +556,8 @@
   min-height: calc(100dvh - var(--mobile-nav-height, 64px));
   padding-bottom: calc(
     var(--mobile-nav-height, 64px) +
-    max(
-      var(--mobile-nav-bottom, env(safe-area-inset-bottom, 0px)),
-      env(safe-area-inset-bottom, 0px)
-    )
+    var(--mobile-nav-bottom, 0px) +
+    env(safe-area-inset-bottom, 0px)
   );
 }
 
@@ -568,10 +566,8 @@
     min-height: calc(100vh - var(--mobile-nav-height, 64px));
     padding-bottom: calc(
       var(--mobile-nav-height, 64px) +
-      max(
-        var(--mobile-nav-bottom, env(safe-area-inset-bottom, 0px)),
-        env(safe-area-inset-bottom, 0px)
-      )
+      var(--mobile-nav-bottom, 0px) +
+      env(safe-area-inset-bottom, 0px)
     );
   }
 }
@@ -585,6 +581,6 @@
   }
 }
 :root {
-  --mobile-nav-bottom: env(safe-area-inset-bottom, 0px);
+  --mobile-nav-bottom: 0px;
   --mobile-nav-height: 64px;
 }


### PR DESCRIPTION
## Summary
- pad mobile main layout to account for the fixed navigation height and bottom inset so content clears the nav
- mirror the same padding fallback for browsers without dynamic viewport support

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68e670d7517c8327be64ee7cac201792